### PR TITLE
Fix grid participant labels and highlight border with zero margins

### DIFF
--- a/compositions/daily-baseline/layouts.js
+++ b/compositions/daily-baseline/layouts.js
@@ -76,6 +76,11 @@ export function gridLabel(parentFrame, params) {
   h = Math.ceil(textH * 1.6); // enough room for one line of text
   y += parentFrame.h - h; // bottom-aligned inside the tile
 
+  // ensure x and y are never exactly 0, which would be treated as falsy
+  // by the canvas text renderer and cause the label to not render
+  if (x === 0) x = 0.5;
+  if (y === 0) y = 0.5;
+
   return { x, y, w, h };
 }
 

--- a/compositions/daily-baseline/layouts.js
+++ b/compositions/daily-baseline/layouts.js
@@ -73,9 +73,8 @@ export function gridLabel(parentFrame, params) {
   const { textH = 20, offsets = {} } = params;
   let { x, y, w, h } = offset(parentFrame, offsets);
 
-  y += parentFrame.h + Math.round(textH * 0.1);
-
   h = Math.ceil(textH * 1.6); // enough room for one line of text
+  y += parentFrame.h - h; // bottom-aligned inside the tile
 
   return { x, y, w, h };
 }

--- a/js/devrig/vcs-rig.html
+++ b/js/devrig/vcs-rig.html
@@ -560,6 +560,11 @@ table {
             </div>
             <div id="controls">
 
+              <div class="vc" style="padding: 0.5em 1em; background: var(--bg-color-lighter1);">
+                <h3 style="margin-top: 0.5em;">Test presets</h3>
+                <button id="applySTR1958Btn" style="font-size: 12px;">STR-1958: Zero margin grid labels</button>
+              </div>
+
               <div class="vc">
                 <h3>Media input</h3>
                 <div class="mediaInput">
@@ -2254,6 +2259,57 @@ function sendParam(paramId, value) {
     printApicallRec();
   }
 }
+
+function applyPreset_STR1958() {
+  const params = {
+    "videoSettings.margin.bottom_gu": 0,
+    "videoSettings.margin.top_gu": 0,
+    "videoSettings.margin.left_gu": 0,
+    "videoSettings.margin.right_gu": 0,
+    "videoSettings.omitPausedVideo": false,
+    "videoSettings.omitAudioOnly": false,
+    "videoSettings.showParticipantLabels": true,
+    "videoSettings.labels.fontFamily": "DMSans",
+    "videoSettings.highlight.color": "rgb(34, 176, 125)",
+    "videoSettings.highlight.stroke_gu": 0.2,
+    "showBannerOverlay": false,
+    "showTextOverlay": false,
+    "showTitleSlate": false,
+    "showImageOverlay": true,
+    "mode": "grid",
+    "videoSettings.maxCamStreams": 20,
+    "videoSettings.preferScreenshare": false,
+    "videoSettings.scaleMode": "fill",
+    "videoSettings.grid.preserveAspectRatio": true,
+    "videoSettings.grid.outerPadding_gu": 0,
+    "videoSettings.dominant.followDomFlag": false,
+    "videoSettings.dominant.itemInterval_gu": 0.2,
+    "videoSettings.dominant.outerPadding_gu": 0,
+  };
+  for (const [key, value] of Object.entries(params)) {
+    sendParam(key, value);
+  }
+  // update UI controls to reflect new values
+  document.querySelectorAll('#controls [data-param-id]').forEach(el => {
+    const paramId = el.dataset.paramId;
+    if (!(paramId in params)) return;
+    const value = params[paramId];
+    if (el.tagName === 'INPUT' && el.type === 'checkbox') {
+      el.checked = !!value;
+    } else if (el.tagName === 'INPUT') {
+      el.value = value;
+    } else if (el.tagName === 'SELECT') {
+      for (let i = 0; i < el.options.length; i++) {
+        if (el.options[i].value === String(value)) {
+          el.selectedIndex = i;
+          break;
+        }
+      }
+    }
+  });
+}
+
+document.getElementById('applySTR1958Btn').addEventListener('click', applyPreset_STR1958);
 
 function sendStandardSource(sourceId, data) {
   if (!g_vcsApi) return;

--- a/js/src/render/canvas.js
+++ b/js/src/render/canvas.js
@@ -657,7 +657,7 @@ function drawEmoji(ctx, emoji, x, y, w, h, isInline = true) {
 
 function drawStyledText(ctx, text, fontMetrics, style, frame, comp) {
   // ensure we have coordinates
-  if (!frame?.x || !frame?.y) return;
+  if (frame?.x == null || frame?.y == null) return;
 
   // when encoding a display list, prefer more easily parsed format
   const isVCSDisplayListEncoder =

--- a/js/src/render/canvas.js
+++ b/js/src/render/canvas.js
@@ -500,25 +500,32 @@ function recurseRenderNode(
 
     if (inShapeClip) ctx.restore();
 
-    // stroke needs to be rendered after clip
+    // stroke needs to be rendered after clip.
+    // inset by half stroke width so the entire stroke is drawn inside the frame.
     if (strokeColor && Number.isFinite(strokeW_px) && strokeW_px > 0) {
       ctx.strokeStyle = ensureCssColor(strokeColor);
       ctx.lineWidth = strokeW_px;
+
+      const halfStroke = strokeW_px / 2;
+      const sx = frame.x + halfStroke;
+      const sy = frame.y + halfStroke;
+      const sw = frame.w - strokeW_px;
+      const sh = frame.h - strokeW_px;
 
       if (hasCornerRadius) {
         ctx.save();
         roundRect(
           ctx,
-          frame.x,
-          frame.y,
-          frame.w,
-          frame.h,
+          sx,
+          sy,
+          sw,
+          sh,
           node.style.cornerRadius_px
         );
         ctx.stroke();
         ctx.restore();
       } else {
-        ctx.strokeRect(frame.x, frame.y, frame.w, frame.h);
+        ctx.strokeRect(sx, sy, sw, sh);
       }
     }
   } // end if (writeContent)


### PR DESCRIPTION
## Summary
- **Position grid labels inside tiles** instead of below them. `gridLabel()` previously placed labels at `y = parentFrame.h + offset` (below the tile), which caused them to render off-canvas or get painted over by subsequent tiles when `outerPadding_gu: 0` and all `videoSettings.margin.*_gu: 0`. Now labels are bottom-aligned inside the tile (`y = parentFrame.h - h`).
- **Inset highlight stroke by half stroke width** so the full border renders inside tile bounds. Previously `strokeRect` drew the stroke centered on the boundary, causing the outer half to be clipped by canvas edges or occluded by adjacent tiles.
- Fixes STR-1958

## Test plan
- [x] Test grid mode with the exact reproduction params (all margins 0, `outerPadding_gu: 0`, `showParticipantLabels: true`)
- [x] Verify labels render for ALL tiles including bottom row
- [x] Test with 2, 3, 4, 5, 9, 16+ participants
- [x] Test with default auto settings (`outerPadding_gu: -1`) for visual regression check
- [x] Test viewport aspect ratios: 16:9, 9:16, 1:1
- [x] Verify highlight border renders on all 4 edges of highlighted tile
- [x] Verify single participant, dominant, and pip modes are unaffected
- [x] Check Toast and Banner stroked elements still look correct after stroke inset change

🤖 Generated with [Claude Code](https://claude.com/claude-code)